### PR TITLE
Allow Steps to Run Earlier

### DIFF
--- a/.github/workflows/update-agents.yml
+++ b/.github/workflows/update-agents.yml
@@ -5,9 +5,9 @@ name: Update Agents
 # separate PR for each major bump. Versions published in the last 24 hours are
 # excluded (cool-down, similar to dependabot's cooldown feature).
 #
-# Note: PRs are created with the default GITHUB_TOKEN, which means they will
-# NOT trigger validate.yml automatically. To run CI on a PR opened by this
-# workflow, push an empty commit or close-and-reopen the PR.
+# Auth: PRs are created with a fine-grained PAT stored as an environment
+# secret on the `agent-updates` environment (scoped to this repo, with
+# Contents + Pull requests write). The default GITHUB_TOKEN is unused.
 
 on:
   schedule:
@@ -19,9 +19,8 @@ jobs:
   update:
     name: Check npm for agent updates
     runs-on: ubuntu-24.04
-    permissions:
-      contents: write
-      pull-requests: write
+    environment: agent-updates
+    permissions: {}
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -36,7 +35,7 @@ jobs:
 
       - name: Find updates and open PRs
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.UPDATE_AGENTS_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail

--- a/README.md
+++ b/README.md
@@ -128,6 +128,13 @@ uv = ""
 nodejs = ""
 
 [build]
+root_steps = [
+    '''RUN curl -fsSL https://pki.acme.example/root-ca.crt -o /tmp/internal-ca.crt \
+     && openssl x509 -in /tmp/internal-ca.crt -noout -fingerprint -sha256 \
+        | grep -q 'SHA256 Fingerprint=3A:1B:5C:...:FF' \
+     && mv /tmp/internal-ca.crt /usr/local/share/ca-certificates/internal-ca.crt \
+     && update-ca-certificates''',
+]
 custom_steps = [
     'RUN sudo apt-get update && sudo apt-get install -y postgresql-client',
 ]
@@ -147,6 +154,7 @@ AWS_PROFILE = "dev"
 |-------|----------|
 | `agent` | Project overrides global |
 | `tools` | Union (deduplicated by name; project version overrides) |
+| `build.root_steps` | Concatenated (global first, then project) |
 | `build.custom_steps` | Concatenated (global first, then project) |
 | `volumes` | Union (project overrides if same container path) |
 | `environment` | Merged (project keys override global) |
@@ -245,7 +253,7 @@ build still proceeds with the built-in catalog.
     {
       "name": "internal-cli",
       "description": "Acme internal CLI",
-      "source_image": "registry.acme.internal/tools/internal-cli",
+      "source_image": "registry.acme.example/tools/internal-cli",
       "default_tag": "1.2.3",
       "instructions": [
         "COPY --from=%s /usr/bin/internal-cli /usr/local/bin/internal-cli"
@@ -374,13 +382,13 @@ can override it:
   "description": "Acme internal CLI",
   "default_tag": "4.2.1",
   "instructions": [
-    "RUN curl -fsSL https://downloads.acme.com/cli/v{{.Tag}}/acme-linux-amd64 -o /usr/local/bin/acme && chmod +x /usr/local/bin/acme"
+    "RUN curl -fsSL https://downloads.acme.example/cli/v{{.Tag}}/acme-linux-amd64 -o /usr/local/bin/acme && chmod +x /usr/local/bin/acme"
   ]
 }
 ```
 
 Passing `-v acme-cli=4.3.0` will render
-`https://downloads.acme.com/cli/v4.3.0/...` without any catalog change.
+`https://downloads.acme.example/cli/v4.3.0/...` without any catalog change.
 
 A malformed template surfaces as a clear error at resolve time (e.g.
 `tool "acme-cli": parsing instruction "...": template: instr:1: ...`) — the
@@ -422,6 +430,27 @@ custom_steps = [
 Only **RUN**, **COPY**, and **ADD** are allowed. Other instructions (ENV, WORKDIR, etc.) are lost during the single-layer squash.
 
 COPY/ADD source paths resolve relative to the project's `common/` directory.
+
+### Early root steps
+
+`build.root_steps` injects instructions **earlier** in the build, immediately after the base `apt` setup and before any network-fetching steps (including the `zsh-in-docker` install and all dev-tool installs). Use it when later steps need the setup in place — for example, installing an internal CA certificate or a private apt source before anything tries to `curl` from internal infrastructure.
+
+Fetch what you need over the network and verify it — don't try to stage local files into the build. A CA-cert install looks like:
+
+```toml
+[build]
+root_steps = [
+    '''RUN curl -fsSL https://pki.acme.example/root-ca.crt -o /tmp/internal-ca.crt \
+     && openssl x509 -in /tmp/internal-ca.crt -noout -fingerprint -sha256 \
+        | grep -q 'SHA256 Fingerprint=3A:1B:5C:...:FF' \
+     && mv /tmp/internal-ca.crt /usr/local/share/ca-certificates/internal-ca.crt \
+     && update-ca-certificates''',
+]
+```
+
+`openssl x509 -fingerprint` hashes the DER encoding of the certificate itself, not the file bytes — so it matches what your CA publishes and is stable against whitespace or line-ending churn on the server. If the fingerprint doesn't match, `grep -q` fails, `&&` short-circuits, the cert never gets moved into the trust store, and the build aborts — you never silently trust a new root.
+
+`root_steps` run as `root`, early. `custom_steps` run later, after tools are installed. Pick `root_steps` only when something downstream (network fetch, apt source, trust store) depends on the setup being in place; otherwise prefer `custom_steps`.
 
 ## Project Directories
 

--- a/embedded/Dockerfile.tmpl
+++ b/embedded/Dockerfile.tmpl
@@ -30,6 +30,11 @@ RUN apt update && apt upgrade -y \
   && touch /commandhistory/.bash_history /commandhistory/.zsh_history \
   && chown -R coder:coder /workspace /home/coder /commandhistory
 
+# ── Root setup steps ─────────────────────────────────
+{{ range .RootSteps }}
+{{ . }}
+{{ end }}
+
 USER coder
 WORKDIR /workspace
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,6 +46,7 @@ func (cfg *Config) SetTools(entries []ToolEntry) {
 // BuildConfig holds custom Dockerfile build steps.
 type BuildConfig struct {
 	CustomSteps []string `toml:"custom_steps"`
+	RootSteps   []string `toml:"root_steps"`
 }
 
 // Volume represents an additional volume mount.
@@ -165,6 +166,7 @@ func Save(cfg *Config, path string) error {
 // - agent: project overrides global
 // - tools: union (deduplicated by name; project version overrides)
 // - build.custom_steps: concatenated (global first, then project)
+// - build.root_steps: concatenated (global first, then project)
 // - volumes: union (project overrides if same container path)
 // - environment: merged (project keys override global)
 func Merge(global, project *Config) *Config {
@@ -188,6 +190,10 @@ func Merge(global, project *Config) *Config {
 	// Build.CustomSteps: concatenated.
 	result.Build.CustomSteps = append(result.Build.CustomSteps, global.Build.CustomSteps...)
 	result.Build.CustomSteps = append(result.Build.CustomSteps, project.Build.CustomSteps...)
+
+	// Build.RootSteps: concatenated.
+	result.Build.RootSteps = append(result.Build.RootSteps, global.Build.RootSteps...)
+	result.Build.RootSteps = append(result.Build.RootSteps, project.Build.RootSteps...)
 
 	// Volumes: union, project overrides by container path.
 	volMap := make(map[string]Volume)
@@ -234,6 +240,12 @@ func Validate(cfg *Config) error {
 	}
 
 	for _, step := range cfg.Build.CustomSteps {
+		if err := validateCustomStep(step); err != nil {
+			return err
+		}
+	}
+
+	for _, step := range cfg.Build.RootSteps {
 		if err := validateCustomStep(step); err != nil {
 			return err
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -20,6 +21,9 @@ uv = "0.5"
 [build]
 custom_steps = [
     'RUN apt-get update',
+]
+root_steps = [
+    "RUN curl -fsSL https://pki.acme.example/root-ca.crt -o /tmp/ca.crt && openssl x509 -in /tmp/ca.crt -noout -fingerprint -sha256 | grep -q 'SHA256 Fingerprint=AA:BB' && mv /tmp/ca.crt /usr/local/share/ca-certificates/internal-ca.crt && update-ca-certificates",
 ]
 
 [[volumes]]
@@ -51,6 +55,12 @@ AWS_PROFILE = "dev"
 	}
 	if len(cfg.Build.CustomSteps) != 1 {
 		t.Fatalf("expected 1 custom step, got %d", len(cfg.Build.CustomSteps))
+	}
+	if len(cfg.Build.RootSteps) != 1 {
+		t.Fatalf("expected 1 root step, got %d", len(cfg.Build.RootSteps))
+	}
+	if !strings.Contains(cfg.Build.RootSteps[0], "update-ca-certificates") {
+		t.Errorf("expected root step to contain 'update-ca-certificates', got %q", cfg.Build.RootSteps[0])
 	}
 	if len(cfg.Volumes) != 1 {
 		t.Fatalf("expected 1 volume, got %d", len(cfg.Volumes))
@@ -190,6 +200,22 @@ func TestMergeCustomSteps(t *testing.T) {
 	}
 }
 
+func TestMergeRootSteps(t *testing.T) {
+	global := &Config{Build: BuildConfig{RootSteps: []string{"RUN echo global-root"}}}
+	project := &Config{Build: BuildConfig{RootSteps: []string{"RUN echo project-root"}}}
+	result := Merge(global, project)
+
+	if len(result.Build.RootSteps) != 2 {
+		t.Fatalf("expected 2 root steps, got %d", len(result.Build.RootSteps))
+	}
+	if result.Build.RootSteps[0] != "RUN echo global-root" {
+		t.Errorf("expected first step 'RUN echo global-root', got %q", result.Build.RootSteps[0])
+	}
+	if result.Build.RootSteps[1] != "RUN echo project-root" {
+		t.Errorf("expected second step 'RUN echo project-root', got %q", result.Build.RootSteps[1])
+	}
+}
+
 func TestMergeVolumes(t *testing.T) {
 	global := &Config{
 		Volumes: []Volume{
@@ -271,6 +297,32 @@ func TestValidate(t *testing.T) {
 		}
 		if err := Validate(cfg); err == nil {
 			t.Error("expected error for invalid custom step (ENV)")
+		}
+	})
+
+	t.Run("invalid root step", func(t *testing.T) {
+		cfg := &Config{
+			Agent: "claude",
+			Build: BuildConfig{RootSteps: []string{"ENV FOO=bar"}},
+		}
+		err := Validate(cfg)
+		if err == nil {
+			t.Fatal("expected error for invalid root step (ENV)")
+		}
+		if !strings.Contains(err.Error(), "single-layer squash") {
+			t.Errorf("expected squash error message, got %q", err.Error())
+		}
+	})
+
+	t.Run("valid root steps", func(t *testing.T) {
+		cfg := &Config{
+			Agent: "claude",
+			Build: BuildConfig{RootSteps: []string{
+				"RUN curl -fsSL https://pki.acme.example/root-ca.crt -o /tmp/ca.crt && openssl x509 -in /tmp/ca.crt -noout -fingerprint -sha256 | grep -q 'SHA256 Fingerprint=AA:BB' && mv /tmp/ca.crt /usr/local/share/ca-certificates/internal-ca.crt && update-ca-certificates",
+			}},
+		}
+		if err := Validate(cfg); err != nil {
+			t.Errorf("unexpected error: %v", err)
 		}
 	})
 

--- a/internal/docker/dockerfile.go
+++ b/internal/docker/dockerfile.go
@@ -17,6 +17,7 @@ import (
 // RenderData holds all values injected into the Dockerfile template.
 type RenderData struct {
 	ToolInstructions []string // rendered tool Dockerfile lines
+	RootSteps        []string // raw root-level Dockerfile steps (pre-tools)
 	CustomSteps      []string // raw custom Dockerfile steps
 	AgentInstall     string   // agent install RUN command
 	AgentExtraEnv    []string // agent extra ENV lines ("KEY=VALUE")
@@ -105,6 +106,7 @@ func RenderDockerfile(cfg *config.Config) (string, error) {
 
 	data := RenderData{
 		ToolInstructions: toolLines,
+		RootSteps:        cfg.Build.RootSteps,
 		CustomSteps:      cfg.Build.CustomSteps,
 		AgentInstall:     meta.InstallCmd,
 		AgentExtraEnv:    envLines,

--- a/internal/docker/dockerfile_test.go
+++ b/internal/docker/dockerfile_test.go
@@ -130,6 +130,47 @@ func TestRenderDockerfileWithCustomSteps(t *testing.T) {
 	}
 }
 
+func TestRenderDockerfileWithRootSteps(t *testing.T) {
+	cfg := &config.Config{
+		Agent: "claude",
+		Build: config.BuildConfig{
+			RootSteps: []string{
+				"RUN curl -fsSL https://pki.acme.example/root-ca.crt -o /tmp/ca.crt && openssl x509 -in /tmp/ca.crt -noout -fingerprint -sha256 | grep -q 'SHA256 Fingerprint=AA:BB' && mv /tmp/ca.crt /usr/local/share/ca-certificates/internal-ca.crt && update-ca-certificates",
+			},
+		},
+	}
+
+	result, err := RenderDockerfile(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(result, "update-ca-certificates") {
+		t.Error("should contain root step")
+	}
+
+	rootStepIdx := strings.Index(result, "update-ca-certificates")
+	userCoderIdx := strings.Index(result, "USER coder")
+	zshIdx := strings.Index(result, "zsh-in-docker")
+	toolUserRootIdx := strings.Index(result, "# ── Bundled dev tools")
+
+	if rootStepIdx == -1 {
+		t.Fatal("root step not found in rendered output")
+	}
+	if userCoderIdx == -1 {
+		t.Fatal("USER coder not found in rendered output")
+	}
+	if rootStepIdx >= userCoderIdx {
+		t.Error("root step should appear before the first USER coder switch")
+	}
+	if zshIdx != -1 && rootStepIdx >= zshIdx {
+		t.Error("root step should appear before zsh-in-docker install")
+	}
+	if toolUserRootIdx != -1 && rootStepIdx >= toolUserRootIdx {
+		t.Error("root step should appear before bundled dev tools block")
+	}
+}
+
 func TestRenderDockerfileInvalidAgent(t *testing.T) {
 	cfg := &config.Config{Agent: "invalid"}
 	_, err := RenderDockerfile(cfg)

--- a/internal/tool/custom_tools_test.go
+++ b/internal/tool/custom_tools_test.go
@@ -72,7 +72,7 @@ func TestLoadCustomToolsFromValid(t *testing.T) {
 			},
 			{
 				"name": "internal-cli",
-				"source_image": "registry.acme.internal/tools/internal-cli",
+				"source_image": "registry.acme.example/tools/internal-cli",
 				"default_tag": "1.2.3",
 				"instructions": ["COPY --from=%s /usr/bin/internal-cli /usr/local/bin/internal-cli"]
 			}
@@ -94,7 +94,7 @@ func TestLoadCustomToolsFromValid(t *testing.T) {
 	if len(f.Tools[0].Instructions) != 1 {
 		t.Errorf("expected 1 instruction for htop, got %d", len(f.Tools[0].Instructions))
 	}
-	if f.Tools[1].SourceImage != "registry.acme.internal/tools/internal-cli" {
+	if f.Tools[1].SourceImage != "registry.acme.example/tools/internal-cli" {
 		t.Errorf("source_image not parsed correctly: %q", f.Tools[1].SourceImage)
 	}
 	if len(f.Ignore) != 2 || f.Ignore[0] != "ruby" || f.Ignore[1] != "php" {

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -340,10 +340,10 @@ var builtinCatalog = []Tool{
 		Name:         "tflint",
 		Category:     "cloud",
 		Description:  "TFLint Terraform linter",
+		DefaultTag:   "0.61.0",
 		Dependencies: []string{"terraform"},
 		Instructions: []string{
-			`RUN TFLINT_VERSION=0.61.0 \` + "\n" +
-				`  && curl -fsSL "https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/tflint_linux_$(dpkg --print-architecture).zip" -o /tmp/tflint.zip \` + "\n" +
+			`RUN curl -fsSL "https://github.com/terraform-linters/tflint/releases/download/v{{.Tag}}/tflint_linux_$(dpkg --print-architecture).zip" -o /tmp/tflint.zip \` + "\n" +
 				`  && unzip -o /tmp/tflint.zip -d /usr/local/bin \` + "\n" +
 				`  && rm /tmp/tflint.zip`,
 		},

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -337,6 +337,16 @@ var builtinCatalog = []Tool{
 		},
 	},
 	{
+		Name:        "terraform-docs",
+		Category:    "cloud",
+		Description: "terraform-docs documentation generator",
+		SourceImage: "quay.io/terraform-docs/terraform-docs",
+		DefaultTag:  "0.22.0-arm64", // TODO: Remove arch when upstream fixes their builds
+		Instructions: []string{
+			"COPY --from=%s /usr/local/bin/terraform-docs /usr/local/bin/terraform-docs",
+		},
+	},
+	{
 		Name:         "tflint",
 		Category:     "cloud",
 		Description:  "TFLint Terraform linter",

--- a/internal/tool/tool_test.go
+++ b/internal/tool/tool_test.go
@@ -357,7 +357,7 @@ func TestRenderInstructionsCustomTool(t *testing.T) {
 		Tool: Tool{
 			Name:        "acme",
 			Category:    "custom",
-			SourceImage: "registry.acme.internal/acme",
+			SourceImage: "registry.acme.example/acme",
 			DefaultTag:  "9.8.7-beta",
 			TagSuffix:   "-beta",
 			Instructions: []string{
@@ -375,13 +375,13 @@ func TestRenderInstructionsCustomTool(t *testing.T) {
 	if len(lines) != 3 {
 		t.Fatalf("expected 3 lines, got %d", len(lines))
 	}
-	if lines[0] != "COPY --from=registry.acme.internal/acme:9.8.7-beta /usr/bin/acme /usr/local/bin/acme" {
+	if lines[0] != "COPY --from=registry.acme.example/acme:9.8.7-beta /usr/bin/acme /usr/local/bin/acme" {
 		t.Errorf("line 0 = %q", lines[0])
 	}
 	if lines[1] != "RUN /usr/local/bin/acme --version | grep 9.8.7" {
 		t.Errorf("line 1 = %q", lines[1])
 	}
-	if lines[2] != "LABEL acme.tag=9.8.7-beta acme.ref=registry.acme.internal/acme:9.8.7-beta" {
+	if lines[2] != "LABEL acme.tag=9.8.7-beta acme.ref=registry.acme.example/acme:9.8.7-beta" {
 		t.Errorf("line 2 = %q", lines[2])
 	}
 }


### PR DESCRIPTION
Introduce `root_steps` to allow steps to run immediately after the initial setup steps run. They run as root. This is good for installing CA certs and the like.

Cleaned up the docs to use `.example` domains consistently, as per RFC2606.

Additional changes:
* Make tflint version configurable
* Add terraform-docs