### PR TITLE
Moar tools and version bumps

### DIFF
--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -117,7 +117,7 @@ var builtinCatalog = []Tool{
 		Category:    "runtime",
 		Description: "Node.js",
 		SourceImage: "public.ecr.aws/docker/library/node",
-		DefaultTag:  "22",
+		DefaultTag:  "24",
 		TagSuffix:   "-slim",
 		Instructions: []string{
 			"COPY --from=%s /usr/local/bin/node /usr/local/bin/node",

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -418,6 +418,19 @@ var builtinCatalog = []Tool{
 
 	// ── utils ─────────────────────────────────────────────────────────────
 	{
+		Name:        "acli",
+		Category:    "utils",
+		Description: "Atlassian CLI",
+		Instructions: []string{
+			`RUN mkdir -p -m 755 /etc/apt/keyrings \` + "\n" +
+				`  && curl -fsSL https://acli.atlassian.com/gpg/public-key.asc | gpg --dearmor -o /etc/apt/keyrings/acli-archive-keyring.gpg \` + "\n" +
+				`  && chmod go+r /etc/apt/keyrings/acli-archive-keyring.gpg \` + "\n" +
+				`  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/acli-archive-keyring.gpg] https://acli.atlassian.com/linux/deb stable main" > /etc/apt/sources.list.d/acli.list \` + "\n" +
+				`  && apt update && apt install -y --no-install-recommends acli \` + "\n" +
+				`  && rm -rf /var/lib/apt/lists/*`,
+		},
+	},
+	{
 		Name:        "gh",
 		Category:    "utils",
 		Description: "GitHub CLI",
@@ -436,6 +449,26 @@ var builtinCatalog = []Tool{
 		Description: "GNU Make",
 		Instructions: []string{
 			"RUN apt update && apt install -y --no-install-recommends make && rm -rf /var/lib/apt/lists/*",
+		},
+	},
+	{
+		Name:        "op",
+		Category:    "utils",
+		Description: "1Password CLI",
+		SourceImage: "1password/op",
+		DefaultTag:  "2",
+		Instructions: []string{
+			"COPY --from=%s /usr/local/bin/op /usr/local/bin/op",
+		},
+	},
+	{
+		Name:        "pinact",
+		Category:    "utils",
+		Description: "Pin GitHub Actions versions",
+		DefaultTag:  "3.9.0",
+		Instructions: []string{
+			`RUN curl -fsSL "https://github.com/suzuki-shunsuke/pinact/releases/download/v{{.Tag}}/pinact_linux_$(dpkg --print-architecture).tar.gz" \` + "\n" +
+				`  | tar xz -C /usr/local/bin pinact`,
 		},
 	},
 	{

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -91,7 +91,7 @@ var builtinCatalog = []Tool{
 		Category:    "runtime",
 		Description: "Go",
 		SourceImage: "public.ecr.aws/docker/library/golang",
-		DefaultTag:  "1.24",
+		DefaultTag:  "1.26",
 		Instructions: []string{
 			"COPY --from=%s /usr/local/go /usr/local/go",
 			"RUN ln -sf /usr/local/go/bin/go /usr/local/bin/go && ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt",

--- a/internal/tool/tool_test.go
+++ b/internal/tool/tool_test.go
@@ -162,8 +162,8 @@ func TestDefaultVersion(t *testing.T) {
 		t.Errorf("expected 3.13, got %q", python.DefaultVersion())
 	}
 	golang, _ := Get("golang")
-	if golang.DefaultVersion() != "1.24" {
-		t.Errorf("expected 1.24, got %q", golang.DefaultVersion())
+	if golang.DefaultVersion() != "1.26" {
+		t.Errorf("expected 1.26, got %q", golang.DefaultVersion())
 	}
 	java, _ := Get("java")
 	if java.DefaultVersion() != "21" {


### PR DESCRIPTION
Default go 1.24 -> 1.26
Default node 22 -> 24
Add new tools:
* Atlassian CLI
* 1Password CLI
* pinact