### PR TITLE
adding imagemagick to utils tools

### DIFF
--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -462,6 +462,14 @@ var builtinCatalog = []Tool{
 			"GH_TELEMETRY": "false",
 		},
 	},
+		{
+		Name:        "imagemagick",
+		Category:    "utils",
+		Description: "ImageMagick image processing suite",
+		Instructions: []string{
+			`RUN apt update && apt install -y imagemagick libmagickcore-7.q16-10-extra && rm -rf /var/lib/apt/lists/*`,
+		},
+	},
 	{
 		Name:        "make",
 		Category:    "utils",


### PR DESCRIPTION
This PR adds imagemagick to the utils category in the tool catalog. Builds from source with version pinning (default 7.1.2-23) and includes common image format delegates (PNG, JPEG, WebP, TIFF, FreeType, SVG).