### PR TITLE
Update agents: copilot,claude,opencode

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -71,7 +71,7 @@ var registry = map[Agent]Meta{
 		ConfigDir:  ".claude",
 		ExtraFiles: []string{".claude.json"},
 		ExtraDirs:  []string{".claude-plugin"},
-		InstallCmd: `RUN npm install -g @anthropic-ai/claude-code@v2.1.147`,
+		InstallCmd: `RUN npm install -g @anthropic-ai/claude-code@v2.1.150`,
 		Entrypoint: []string{"claude", "--dangerously-skip-permissions"},
 		DependsOn:  []string{"nodejs"},
 	},
@@ -85,7 +85,7 @@ var registry = map[Agent]Meta{
 	Copilot: {
 		Name:       Copilot,
 		ConfigDir:  ".copilot",
-		InstallCmd: `RUN npm install -g @github/copilot@v1.0.51`,
+		InstallCmd: `RUN npm install -g @github/copilot@v1.0.53`,
 		Entrypoint: []string{"copilot", "--allow-all"},
 		DependsOn:  []string{"nodejs"},
 	},
@@ -99,7 +99,7 @@ var registry = map[Agent]Meta{
 	OpenCode: {
 		Name:       OpenCode,
 		ConfigDir:  ".opencode",
-		InstallCmd: `RUN npm install -g opencode-ai@v1.15.7`,
+		InstallCmd: `RUN npm install -g opencode-ai@v1.15.10`,
 		Entrypoint: []string{"opencode"},
 		DependsOn:  []string{"nodejs"},
 	},


### PR DESCRIPTION
## Agent updates

- **copilot** (`@github/copilot`): `v1.0.51` → `v1.0.53` (patch) — [release](https://www.npmjs.com/package/@github/copilot/v/1.0.53)
- **claude** (`@anthropic-ai/claude-code`): `v2.1.147` → `v2.1.150` (patch) — [release](https://www.npmjs.com/package/@anthropic-ai/claude-code/v/2.1.150)
- **opencode** (`opencode-ai`): `v1.15.7` → `v1.15.10` (patch) — [release](https://www.npmjs.com/package/opencode-ai/v/1.15.10)
