### PR TITLE
Update tools: deno, pixi, pnpm, skills, uv, playwright-cli, linear-cli, rumdl, zizmor

### DIFF
--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -303,7 +303,7 @@ var builtinCatalog = []Tool{
 		Category:    "package-manager",
 		Description: "Python package manager (astral-sh/uv)",
 		SourceImage: "ghcr.io/astral-sh/uv",
-		DefaultTag:  "0.12.1",
+		DefaultTag:  "0.12.3",
 		Instructions: []string{
 			"COPY --from=%s /uv /uvx /usr/local/bin/",
 		},

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -496,7 +496,7 @@ var builtinCatalog = []Tool{
 		Name:         "playwright-cli",
 		Category:     "testing",
 		Description:  "Playwright agent CLI with SKILLs (@playwright/cli)",
-		DefaultTag:   "0.1.17",
+		DefaultTag:   "0.1.18",
 		Dependencies: []string{"playwright"},
 		Instructions: []string{
 			`RUN curl -fsSL "https://registry.npmjs.org/@playwright/cli/-/cli-{{.Tag}}.tgz" \` + "\n" +

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -741,7 +741,7 @@ var builtinCatalog = []Tool{
 		Category:    "utils",
 		Description: "GitHub Actions workflow security analyzer",
 		SourceImage: "ghcr.io/zizmorcore/zizmor",
-		DefaultTag:  "1.28.0",
+		DefaultTag:  "1.29.0",
 		Instructions: []string{
 			"COPY --from=%s /usr/bin/zizmor /usr/local/bin/zizmor",
 		},

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -668,7 +668,7 @@ var builtinCatalog = []Tool{
 		Name:        "rumdl",
 		Category:    "utils",
 		Description: "Markdown linter",
-		DefaultTag:  "0.2.47",
+		DefaultTag:  "0.2.52",
 		Instructions: []string{
 			`RUN ARCH=$(dpkg --print-architecture) \` + "\n" +
 				`  && if [ "$ARCH" = "amd64" ]; then ARCH=x86_64; elif [ "$ARCH" = "arm64" ]; then ARCH=aarch64; fi \` + "\n" +

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -278,7 +278,7 @@ var builtinCatalog = []Tool{
 		Name:         "pnpm",
 		Category:     "package-manager",
 		Description:  "pnpm package manager",
-		DefaultTag:   "11.19.0",
+		DefaultTag:   "11.20.0",
 		Dependencies: []string{"nodejs"},
 		Instructions: []string{
 			"RUN npm install -g pnpm@{{.Tag}}",

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -266,7 +266,7 @@ var builtinCatalog = []Tool{
 		Category:    "package-manager",
 		Description: "Conda/PyPI package manager (prefix-dev/pixi)",
 		SourceImage: "ghcr.io/prefix-dev/pixi",
-		DefaultTag:  "0.75.0",
+		DefaultTag:  "0.76.1",
 		TagSuffix:   "-trixie",
 		Instructions: []string{
 			"COPY --from=%s /usr/local/bin/pixi /usr/local/bin/pixi",

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -598,7 +598,7 @@ var builtinCatalog = []Tool{
 		Name:         "linear-cli",
 		Category:     "utils",
 		Description:  "Linear CLI (unofficial)",
-		DefaultTag:   "2.3.0",
+		DefaultTag:   "2.4.0",
 		Dependencies: []string{"nodejs"},
 		Instructions: []string{
 			"RUN npm install -g @schpet/linear-cli@{{.Tag}}",

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -290,7 +290,7 @@ var builtinCatalog = []Tool{
 		Name:         "skills",
 		Category:     "package-manager",
 		Description:  "Vercel skill installer",
-		DefaultTag:   "1.5.21",
+		DefaultTag:   "1.5.22",
 		Dependencies: []string{"nodejs"},
 		Instructions: []string{
 			"RUN npm install -g skills@{{.Tag}}",

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -83,7 +83,7 @@ var builtinCatalog = []Tool{
 		Category:    "runtime",
 		Description: "Deno runtime",
 		SourceImage: "denoland/deno",
-		DefaultTag:  "2.9.4",
+		DefaultTag:  "2.9.5",
 		Instructions: []string{
 			"COPY --from=%s /usr/bin/deno /usr/local/bin/deno",
 		},


### PR DESCRIPTION
## Tool updates

- **deno**: `2.9.4` → `2.9.5` (patch)
- **pixi**: `0.75.0` → `0.76.1` (minor)
- **pnpm**: `11.19.0` → `11.20.0` (minor)
- **skills**: `1.5.21` → `1.5.22` (patch)
- **uv**: `0.12.1` → `0.12.3` (patch)
- **playwright-cli**: `0.1.17` → `0.1.18` (patch)
- **linear-cli**: `2.3.0` → `2.4.0` (minor)
- **rumdl**: `0.2.47` → `0.2.52` (patch)
- **zizmor**: `1.28.0` → `1.29.0` (minor)