### PR TITLE
Update tools: bun, golang, rust, pixi, skills, cloudflare-cli, kubectl, terraform, gh, rumdl, yt-dlp

### DIFF
--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -109,7 +109,7 @@ var builtinCatalog = []Tool{
 		Category:    "runtime",
 		Description: "Go",
 		SourceImage: "public.ecr.aws/docker/library/golang",
-		DefaultTag:  "1.26",
+		DefaultTag:  "1.27",
 		Instructions: []string{
 			"COPY --from=%s /usr/local/go /usr/local/go",
 			"RUN ln -sf /usr/local/go/bin/go /usr/local/bin/go && ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt",

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -402,7 +402,7 @@ var builtinCatalog = []Tool{
 		Category:    "cloud",
 		Description: "HashiCorp Terraform",
 		SourceImage: "public.ecr.aws/hashicorp/terraform",
-		DefaultTag:  "1.15.8",
+		DefaultTag:  "1.15.9",
 		Instructions: []string{
 			"COPY --from=%s /bin/terraform /usr/local/bin/terraform",
 		},

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -290,7 +290,7 @@ var builtinCatalog = []Tool{
 		Name:         "skills",
 		Category:     "package-manager",
 		Description:  "Vercel skill installer",
-		DefaultTag:   "1.5.22",
+		DefaultTag:   "1.5.23",
 		Dependencies: []string{"nodejs"},
 		Instructions: []string{
 			"RUN npm install -g skills@{{.Tag}}",

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -587,7 +587,7 @@ var builtinCatalog = []Tool{
 		Name:        "gh",
 		Category:    "utils",
 		Description: "GitHub CLI",
-		DefaultTag:  "2.97.0",
+		DefaultTag:  "2.98.0",
 		Instructions: []string{
 			`RUN curl -fsSL "https://github.com/cli/cli/releases/download/v{{.Tag}}/gh_{{.Tag}}_linux_$(dpkg --print-architecture).tar.gz" \` + "\n" +
 				`  | tar xz --strip-components=2 -C /usr/local/bin --wildcards '*/bin/gh'`,

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -358,7 +358,7 @@ var builtinCatalog = []Tool{
 		Name:         "cloudflare-cli",
 		Category:     "cloud",
 		Description:  "Cloudflare CLI (cf) — Workers, Pages, DNS, D1, R2, KV, and more",
-		DefaultTag:   "0.6.0",
+		DefaultTag:   "0.8.0",
 		Dependencies: []string{"nodejs"},
 		Instructions: []string{
 			"RUN npm install -g cf@{{.Tag}}",

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -205,7 +205,7 @@ var builtinCatalog = []Tool{
 		Category:    "runtime",
 		Description: "Rust toolchain (includes cargo)",
 		SourceImage: "public.ecr.aws/docker/library/rust",
-		DefaultTag:  "1.97.1",
+		DefaultTag:  "1.98.0",
 		TagSuffix:   "-slim",
 		Instructions: []string{
 			"COPY --from=%s /usr/local/rustup /usr/local/rustup",

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -266,7 +266,7 @@ var builtinCatalog = []Tool{
 		Category:    "package-manager",
 		Description: "Conda/PyPI package manager (prefix-dev/pixi)",
 		SourceImage: "ghcr.io/prefix-dev/pixi",
-		DefaultTag:  "0.76.2",
+		DefaultTag:  "0.77.0",
 		TagSuffix:   "-trixie",
 		Instructions: []string{
 			"COPY --from=%s /usr/local/bin/pixi /usr/local/bin/pixi",

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -70,7 +70,7 @@ var builtinCatalog = []Tool{
 		Category:    "runtime",
 		Description: "Bun runtime",
 		SourceImage: "oven/bun",
-		DefaultTag:  "1.3.14",
+		DefaultTag:  "1.4.0",
 		Instructions: []string{
 			"COPY --from=%s /usr/local/bin/bun /usr/local/bin/bun",
 			"RUN ln -sf /usr/local/bin/bun /usr/local/bin/bunx",

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -389,7 +389,7 @@ var builtinCatalog = []Tool{
 		Name:        "kubectl",
 		Category:    "cloud",
 		Description: "Kubernetes CLI",
-		DefaultTag:  "1.36.3",
+		DefaultTag:  "1.36.4",
 		Instructions: []string{
 			`RUN curl -fsSL "https://dl.k8s.io/release/v{{.Tag}}/bin/linux/$(dpkg --print-architecture)/kubectl" -o /usr/local/bin/kubectl \` + "\n" +
 				`  && chmod +x /usr/local/bin/kubectl`,

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -735,7 +735,7 @@ var builtinCatalog = []Tool{
 		Name:         "yt-dlp",
 		Category:     "utils",
 		Description:  "yt-dlp video downloader",
-		DefaultTag:   "2026.07.04",
+		DefaultTag:   "2026.08.19",
 		Dependencies: []string{"python"},
 		Instructions: []string{
 			`RUN curl -fsSL "https://github.com/yt-dlp/yt-dlp/releases/download/{{.Tag}}/yt-dlp" -o /tmp/yt-dlp \` + "\n" +

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -680,7 +680,7 @@ var builtinCatalog = []Tool{
 		Name:        "rumdl",
 		Category:    "utils",
 		Description: "Markdown linter",
-		DefaultTag:  "0.2.55",
+		DefaultTag:  "0.2.60",
 		Instructions: []string{
 			`RUN ARCH=$(dpkg --print-architecture) \` + "\n" +
 				`  && if [ "$ARCH" = "amd64" ]; then ARCH=x86_64; elif [ "$ARCH" = "arm64" ]; then ARCH=aarch64; fi \` + "\n" +

--- a/internal/tool/tool_test.go
+++ b/internal/tool/tool_test.go
@@ -162,8 +162,8 @@ func TestDefaultVersion(t *testing.T) {
 		t.Errorf("expected 3.14, got %q", python.DefaultVersion())
 	}
 	golang, _ := Get("golang")
-	if golang.DefaultVersion() != "1.26" {
-		t.Errorf("expected 1.26, got %q", golang.DefaultVersion())
+	if golang.DefaultVersion() != "1.27" {
+		t.Errorf("expected 1.27, got %q", golang.DefaultVersion())
 	}
 	java, _ := Get("java")
 	if java.DefaultVersion() != "26" {


### PR DESCRIPTION
## Tool updates

- **bun**: `1.3.14` → `1.4.0` (minor)
- **golang**: `1.26` → `1.27` (minor)
- **rust**: `1.97.1` → `1.98.0` (minor)
- **pixi**: `0.76.2` → `0.77.0` (minor)
- **skills**: `1.5.22` → `1.5.23` (patch)
- **cloudflare-cli**: `0.6.0` → `0.8.0` (minor)
- **kubectl**: `1.36.3` → `1.36.4` (patch)
- **terraform**: `1.15.8` → `1.15.9` (patch)
- **gh**: `2.97.0` → `2.98.0` (minor)
- **rumdl**: `0.2.55` → `0.2.60` (patch)
- **yt-dlp**: `2026.07.04` → `2026.08.19` (minor)