### PR TITLE
Update tools: deno, pixi, uv, kubectl, terraform, golangci-lint, rumdl

### DIFF
--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -749,7 +749,7 @@ var builtinCatalog = []Tool{
 		Name:        "rumdl",
 		Category:    "utils",
 		Description: "Markdown linter",
-		DefaultTag:  "0.2.60",
+		DefaultTag:  "0.2.62",
 		Instructions: []string{
 			`RUN ARCH=$(dpkg --print-architecture) \` + "\n" +
 				`  && if [ "$ARCH" = "amd64" ]; then ARCH=x86_64; elif [ "$ARCH" = "arm64" ]; then ARCH=aarch64; fi \` + "\n" +

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -111,7 +111,7 @@ var builtinCatalog = []Tool{
 		Category:    "runtime",
 		Description: "Deno runtime",
 		SourceImage: "denoland/deno",
-		DefaultTag:  "2.9.5",
+		DefaultTag:  "2.9.6",
 		Instructions: []string{
 			"COPY --from=%s /usr/bin/deno /usr/local/bin/deno",
 		},

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -430,7 +430,7 @@ var builtinCatalog = []Tool{
 		Category:    "cloud",
 		Description: "HashiCorp Terraform",
 		SourceImage: "public.ecr.aws/hashicorp/terraform",
-		DefaultTag:  "1.15.9",
+		DefaultTag:  "1.16.0",
 		Instructions: []string{
 			"COPY --from=%s /bin/terraform /usr/local/bin/terraform",
 		},

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -294,7 +294,7 @@ var builtinCatalog = []Tool{
 		Category:    "package-manager",
 		Description: "Conda/PyPI package manager (prefix-dev/pixi)",
 		SourceImage: "ghcr.io/prefix-dev/pixi",
-		DefaultTag:  "0.77.1",
+		DefaultTag:  "0.78.0",
 		TagSuffix:   "-trixie",
 		Instructions: []string{
 			"COPY --from=%s /usr/local/bin/pixi /usr/local/bin/pixi",

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -417,7 +417,7 @@ var builtinCatalog = []Tool{
 		Name:        "kubectl",
 		Category:    "cloud",
 		Description: "Kubernetes CLI",
-		DefaultTag:  "1.36.4",
+		DefaultTag:  "1.37.0",
 		Instructions: []string{
 			`RUN curl -fsSL "https://dl.k8s.io/release/v{{.Tag}}/bin/linux/$(dpkg --print-architecture)/kubectl" -o /usr/local/bin/kubectl \` + "\n" +
 				`  && chmod +x /usr/local/bin/kubectl`,

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -331,7 +331,7 @@ var builtinCatalog = []Tool{
 		Category:    "package-manager",
 		Description: "Python package manager (astral-sh/uv)",
 		SourceImage: "ghcr.io/astral-sh/uv",
-		DefaultTag:  "0.12.6",
+		DefaultTag:  "0.12.7",
 		Instructions: []string{
 			"COPY --from=%s /uv /uvx /usr/local/bin/",
 		},

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -632,7 +632,7 @@ var builtinCatalog = []Tool{
 		Name:         "golangci-lint",
 		Category:     "utils",
 		Description:  "Go linters aggregator",
-		DefaultTag:   "2.13.1",
+		DefaultTag:   "2.13.2",
 		Dependencies: []string{"golang"},
 		Instructions: []string{
 			`RUN curl -fsSL "https://github.com/golangci/golangci-lint/releases/download/v{{.Tag}}/golangci-lint-{{.Tag}}-linux-$(dpkg --print-architecture).tar.gz" \` + "\n" +


### PR DESCRIPTION
## Tool updates

- **deno**: `2.9.5` → `2.9.6` (patch)
- **pixi**: `0.77.1` → `0.78.0` (minor)
- **uv**: `0.12.6` → `0.12.7` (patch)
- **kubectl**: `1.36.4` → `1.37.0` (minor)
- **terraform**: `1.15.9` → `1.16.0` (minor)
- **golangci-lint**: `2.13.1` → `2.13.2` (patch)
- **rumdl**: `0.2.60` → `0.2.62` (patch)