### PR TITLE
Update tools: bun, composer, pixi, pnpm, uv, cloudflare-cli, terraform, playwright-cli, gh, linear-cli, mermaid-cli, rumdl

### DIFF
--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -430,7 +430,7 @@ var builtinCatalog = []Tool{
 		Category:    "cloud",
 		Description: "HashiCorp Terraform",
 		SourceImage: "public.ecr.aws/hashicorp/terraform",
-		DefaultTag:  "1.16.0",
+		DefaultTag:  "1.16.1",
 		Instructions: []string{
 			"COPY --from=%s /bin/terraform /usr/local/bin/terraform",
 		},

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -294,7 +294,7 @@ var builtinCatalog = []Tool{
 		Category:    "package-manager",
 		Description: "Conda/PyPI package manager (prefix-dev/pixi)",
 		SourceImage: "ghcr.io/prefix-dev/pixi",
-		DefaultTag:  "0.78.0",
+		DefaultTag:  "0.79.0",
 		TagSuffix:   "-trixie",
 		Instructions: []string{
 			"COPY --from=%s /usr/local/bin/pixi /usr/local/bin/pixi",

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -749,7 +749,7 @@ var builtinCatalog = []Tool{
 		Name:        "rumdl",
 		Category:    "utils",
 		Description: "Markdown linter",
-		DefaultTag:  "0.2.62",
+		DefaultTag:  "0.2.64",
 		Instructions: []string{
 			`RUN ARCH=$(dpkg --print-architecture) \` + "\n" +
 				`  && if [ "$ARCH" = "amd64" ]; then ARCH=x86_64; elif [ "$ARCH" = "arm64" ]; then ARCH=aarch64; fi \` + "\n" +

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -306,7 +306,7 @@ var builtinCatalog = []Tool{
 		Name:         "pnpm",
 		Category:     "package-manager",
 		Description:  "pnpm package manager",
-		DefaultTag:   "12.1.0",
+		DefaultTag:   "12.3.4",
 		Dependencies: []string{"nodejs"},
 		Instructions: []string{
 			"RUN npm install -g pnpm@{{.Tag}}",

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -254,7 +254,7 @@ var builtinCatalog = []Tool{
 		Category:     "package-manager",
 		Description:  "Composer PHP package manager",
 		SourceImage:  "public.ecr.aws/docker/library/composer",
-		DefaultTag:   "2.10.2",
+		DefaultTag:   "2.10.3",
 		Dependencies: []string{"php"},
 		Instructions: []string{
 			"COPY --from=%s /usr/bin/composer /usr/local/bin/composer",

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -386,7 +386,7 @@ var builtinCatalog = []Tool{
 		Name:         "cloudflare-cli",
 		Category:     "cloud",
 		Description:  "Cloudflare CLI (cf) — Workers, Pages, DNS, D1, R2, KV, and more",
-		DefaultTag:   "0.8.0",
+		DefaultTag:   "0.9.0",
 		Dependencies: []string{"nodejs"},
 		Instructions: []string{
 			"RUN npm install -g cf@{{.Tag}}",

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -536,7 +536,7 @@ var builtinCatalog = []Tool{
 		Name:         "playwright-cli",
 		Category:     "testing",
 		Description:  "Playwright agent CLI with SKILLs (@playwright/cli)",
-		DefaultTag:   "0.1.18",
+		DefaultTag:   "0.1.19",
 		Dependencies: []string{"playwright"},
 		Instructions: []string{
 			`RUN curl -fsSL "https://registry.npmjs.org/@playwright/cli/-/cli-{{.Tag}}.tgz" \` + "\n" +

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -617,7 +617,7 @@ var builtinCatalog = []Tool{
 		Name:        "gh",
 		Category:    "utils",
 		Description: "GitHub CLI",
-		DefaultTag:  "2.98.0",
+		DefaultTag:  "2.100.0",
 		Instructions: []string{
 			`RUN curl -fsSL "https://github.com/cli/cli/releases/download/v{{.Tag}}/gh_{{.Tag}}_linux_$(dpkg --print-architecture).tar.gz" \` + "\n" +
 				`  | tar xz --strip-components=2 -C /usr/local/bin --wildcards '*/bin/gh'`,

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -653,7 +653,7 @@ var builtinCatalog = []Tool{
 		Name:         "linear-cli",
 		Category:     "utils",
 		Description:  "Linear CLI (unofficial)",
-		DefaultTag:   "2.5.0",
+		DefaultTag:   "2.6.0",
 		Dependencies: []string{"nodejs"},
 		Instructions: []string{
 			"RUN npm install -g @schpet/linear-cli@{{.Tag}}",

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -331,7 +331,7 @@ var builtinCatalog = []Tool{
 		Category:    "package-manager",
 		Description: "Python package manager (astral-sh/uv)",
 		SourceImage: "ghcr.io/astral-sh/uv",
-		DefaultTag:  "0.12.7",
+		DefaultTag:  "0.12.9",
 		Instructions: []string{
 			"COPY --from=%s /uv /uvx /usr/local/bin/",
 		},

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -687,7 +687,7 @@ var builtinCatalog = []Tool{
 		Name:         "mermaid-cli",
 		Category:     "utils",
 		Description:  "Mermaid diagram renderer CLI (mmdc)",
-		DefaultTag:   "11.16.0",
+		DefaultTag:   "11.17.0",
 		Dependencies: []string{"nodejs", "chromium"},
 		Instructions: []string{
 			// Point puppeteer at the apt-installed chromium tool instead of

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -98,7 +98,7 @@ var builtinCatalog = []Tool{
 		Category:    "runtime",
 		Description: "Bun runtime",
 		SourceImage: "oven/bun",
-		DefaultTag:  "1.4.0",
+		DefaultTag:  "1.4.1",
 		Instructions: []string{
 			"COPY --from=%s /usr/local/bin/bun /usr/local/bin/bun",
 			"RUN ln -sf /usr/local/bin/bun /usr/local/bin/bunx",


### PR DESCRIPTION
## Tool updates

- **bun**: `1.4.0` → `1.4.1` (patch)
- **composer**: `2.10.2` → `2.10.3` (patch)
- **pixi**: `0.78.0` → `0.79.0` (minor)
- **pnpm**: `12.1.0` → `12.3.4` (minor)
- **uv**: `0.12.7` → `0.12.9` (patch)
- **cloudflare-cli**: `0.8.0` → `0.9.0` (minor)
- **terraform**: `1.16.0` → `1.16.1` (patch)
- **playwright-cli**: `0.1.18` → `0.1.19` (patch)
- **gh**: `2.98.0` → `2.100.0` (minor)
- **linear-cli**: `2.5.0` → `2.6.0` (minor)
- **mermaid-cli**: `11.16.0` → `11.17.0` (minor)
- **rumdl**: `0.2.62` → `0.2.64` (patch)